### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # See http://about.travis-ci.org/docs/user/build-configuration/
 language: scala
 scala:
-  - 2.11.9
-  - 2.12.4
+  - 2.12.8
 jdk:
   - oraclejdk8
 before_install:

--- a/build.sbt
+++ b/build.sbt
@@ -9,19 +9,19 @@ bintrayOrganization := Some("dividat")
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
-val circeVersion      = "0.9.1"
-val enumeratumVersion = "1.5.13"
-val enumeratumCirceVersion = "1.5.17"
-val catsVersion       = "1.1.0"
-val shapelessVersion  = "2.3.3"
-val ammoniteVersion   = "1.0.5"
+val circeVersion               = "0.13.0"
+val enumeratumVersion          = "1.6.1"
+val enumeratumCirceVersion     = "1.6.1"
+val catsVersion                = "2.1.1"
+val shapelessVersion           = "2.3.3"
+val ammoniteVersion            = "2.2.0"
+val scalaTestVersion           = "3.2.0"
+val jsonSchemaValidatorVersion = "2.2.6"
 
 val readme     = "README.md"
 val readmePath = file(".") / readme
 
-scalaVersion := "2.12.4"
-
-crossScalaVersions := Seq("2.11.9", "2.12.4")
+scalaVersion := "2.12.8"
 
 useGpg := true
 useGpgAgent := true
@@ -41,8 +41,8 @@ libraryDependencies ++= Seq(
   "io.circe"       %% "circe-core"           % circeVersion,
   "io.circe"       %% "circe-parser"         % circeVersion,
   "io.circe"       %% "circe-generic"        % circeVersion,
-  "org.scalatest"  %% "scalatest"            % "3.0.5" % "test",
-  "com.github.fge" % "json-schema-validator" % "2.2.6" % "test",
+  "org.scalatest"  %% "scalatest"            % scalaTestVersion % "test",
+  "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion % "test",
   "com.lihaoyi"    % "ammonite"              % ammoniteVersion % "test" cross CrossVersion.full
 )
 
@@ -92,5 +92,5 @@ val pandocReadme =
        )
        throw e
    }
- 
+
  }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.0
+sbt.version = 1.3.13

--- a/src/test/scala/com/timeout/docless/schema/JsonSchemaTest.scala
+++ b/src/test/scala/com/timeout/docless/schema/JsonSchemaTest.scala
@@ -3,8 +3,8 @@ package com.timeout.docless.schema
 import com.timeout.docless.schema.derive.{Combinator, Config}
 import enumeratum._
 import io.circe._
-import org.scalatest.FreeSpec
-import org.scalatest.Matchers._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.reflect.runtime.{universe => u}
 
@@ -49,7 +49,7 @@ object JsonSchemaTest {
   case class D(enum: TheEnum) extends TheADT
 }
 
-class JsonSchemaTest extends FreeSpec {
+class JsonSchemaTest extends AnyFreeSpec with Matchers {
 
   import JsonSchemaTest._
 

--- a/src/test/scala/com/timeout/docless/schema/derive/PlainEnumTest.scala
+++ b/src/test/scala/com/timeout/docless/schema/derive/PlainEnumTest.scala
@@ -1,10 +1,11 @@
 package com.timeout.docless.schema.derive
 
 import com.timeout.docless.schema.PlainEnum
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import PlainEnum.IdFormat
 
-class PlainEnumTest extends FreeSpec with Matchers {
+class PlainEnumTest extends AnyFreeSpec with Matchers {
   sealed trait TheEnum
   case object EnumA extends TheEnum
   case object EnumB extends TheEnum

--- a/src/test/scala/com/timeout/docless/swagger/PathGroupTest.scala
+++ b/src/test/scala/com/timeout/docless/swagger/PathGroupTest.scala
@@ -1,6 +1,8 @@
 package com.timeout.docless.swagger
 
-import org.scalatest.{FreeSpec, Inside, Matchers}
+import org.scalatest.Inside
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import cats.data.NonEmptyList
 import cats.data.Validated
 import SchemaError._
@@ -8,7 +10,7 @@ import com.timeout.docless.schema.JsonSchema
 import com.timeout.docless.schema.JsonSchema._
 import com.timeout.docless.swagger.Method._
 
-class PathGroupTest extends FreeSpec with Matchers {
+class PathGroupTest extends AnyFreeSpec with Matchers {
   "PathGroup" - {
     val petstore = PetstoreSchema()
     val pet      = PetstoreSchema.Schemas.pet

--- a/src/test/scala/com/timeout/docless/swagger/SwaggerTest.scala
+++ b/src/test/scala/com/timeout/docless/swagger/SwaggerTest.scala
@@ -4,11 +4,11 @@ import com.github.fge.jackson.JsonLoader
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import io.circe._
 import io.circe.syntax._
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import scala.collection.JavaConverters._
 
-class SwaggerTest extends FreeSpec {
+class SwaggerTest extends AnyFreeSpec {
   "Can build and serialise a swagger object" in {
     val petstoreSchema = PetstoreSchema()
     val json           = JsonLoader.fromResource("/swagger-schema.json")


### PR DESCRIPTION
With newer version of circe in caller projects, we get this runtime error:

```sbt
[error] java.lang.NoSuchMethodError: io.circe.Encoder$.encodeJsonObject()Lio/circe/ObjectEncoder;
[error] 	at com.timeout.docless.schema.JsonSchema.asJson(JsonSchema.scala:28)
[error] 	at com.timeout.docless.schema.JsonSchema.asJson$(JsonSchema.scala:28)
[error] 	at com.timeout.docless.schema.JsonSchema$$anon$4.asJson(JsonSchema.scala:155)
[error] 	at com.timeout.docless.schema.derive.HListInstances.$anonfun$hlistSchema$1(HListInstances.scala:26)
[error] 	at com.timeout.docless.schema.JsonSchema$$anon$3.jsonObject(JsonSchema.scala:148)
[error] 	at com.timeout.docless.schema.derive.HListInstances.$anonfun$genericSchema$1(HListInstances.scala:48)
[error] 	at com.timeout.docless.schema.JsonSchema$$anon$3.relatedDefinitions(JsonSchema.scala:149)
[error] 	at com.timeout.docless.schema.JsonSchema.definitions(JsonSchema.scala:49)
[error] 	at com.timeout.docless.schema.JsonSchema.definitions$(JsonSchema.scala:48)
[error] 	at com.timeout.docless.schema.JsonSchema$$anon$3.definitions(JsonSchema.scala:145)
```

By upgrading the dependencies, and releasing a new version, this should fix the above issue.